### PR TITLE
Docker image size reduce

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-FROM python:3.11-alpine3.19
+FROM python:3.11-alpine3.19 AS build
 
 # Build-time flags
 ARG WITH_PLUGINS=true
@@ -90,6 +90,12 @@ RUN \
   git config --system --add safe.directory /docs \
 && \
   git config --system --add safe.directory /site
+
+#  From empty image
+FROM scratch 
+
+# Copy all from build
+COPY --from=build / /
 
 # Set working directory
 WORKDIR /docs


### PR DESCRIPTION
Hello,

This Dockerfile use multi-stage builds to reduce the size of the final image and get a "dive image efficient score" at 100% (94% before).

```
Image name: squidfunk/mkdocs-material:latest
Total Image size: 184 MB
Potential wasted space: 22 MB
Image efficiency score: 94 %

Image name: squidfunk/mkdocs-material:multistage
Total Image size: 159 MB
Potential wasted space: 0 B
Image efficiency score: 100 %
```
[**dive**](https://github.com/wagoodman/dive?tab=readme-ov-file#basic-features)
* A tool for exploring a docker image, layer contents, and discovering ways to shrink the size of your Docker/OCI image.
> **Estimate "image efficiency"**
> The lower left pane shows basic layer info and an experimental metric that will guess how much wasted space your image contains. This might be from duplicating files across layers, moving files across layers, or not fully removing files. Both a percentage "score" and total wasted file space is provided.
